### PR TITLE
Refactor Deck and Deck-Test files

### DIFF
--- a/src/Deck.js
+++ b/src/Deck.js
@@ -1,11 +1,11 @@
 class Deck {
-    constructor(cards) {
-        this.cards = cards;
-    };
+  constructor(cards) {
+    this.cards = cards;
+  };
 
-    countCards() {
-        return this.cards.length;
-    };
+  countCards() {
+    return this.cards.length;
+  };
 };
 
 module.exports = Deck;

--- a/test/Deck-test.js
+++ b/test/Deck-test.js
@@ -4,31 +4,33 @@ const expect = chai.expect;
 const Deck = require('../src/Deck');
 const Card = require('../src/Card');
 
-describe('Deck', function() {
+describe('Deck', () => {
+  let card1;
+  let card2;
+  let card3;
+  let deck;
 
-    it('should be a function', function() {
-        expect(Deck).to.be.a('function');
-    });
+  beforeEach(() => {
+    card1 = new Card(1, 'What allows you to define a set of related information using key-value pairs?', ['object', 'array', 'function'], 'object');
+    card2 = new Card(2, 'What is a comma-separated list of related values?', ['array', 'object', 'function'], 'array');
+    card3 = new Card(3, 'What type of prototype method directly modifies the existing array?', ['mutator method', 'accessor method', 'iteration method'], 'mutator method');
+    deck = new Deck([card1, card2, card3]);
+  });
 
-    it('should be an instance of Deck', function() {
-        const deck = new Deck();
-        expect(deck).to.be.an.instanceOf(Deck);
-    });
+  it('should be a function', () => {
+    expect(Deck).to.be.a('function');
+  });
 
-    it('should initialize with a an array of cards', function () {
-        const card1 = new Card(1, 'What allows you to define a set of related information using key-value pairs?', ['object', 'array', 'function'], 'object');
-        const card2 = new Card(2, 'What is a comma-separated list of related values?', ['array', 'object', 'function'], 'array');
-        const card3 = new Card(3, 'What type of prototype method directly modifies the existing array?', ['mutator method', 'accessor method', 'iteration method'], 'mutator method');
-        const deck = new Deck([card1, card2, card3]);
-        expect(deck.cards).to.deep.equal([card1, card2, card3]);
-    });
+  it('should be an instance of Deck', () => {
+    expect(deck).to.be.an.instanceOf(Deck);
+  });
 
-    it('should know how many cards are in the deck', function() {
-        const card1 = new Card(1, 'What allows you to define a set of related information using key-value pairs?', ['object', 'array', 'function'], 'object');
-        const card2 = new Card(2, 'What is a comma-separated list of related values?', ['array', 'object', 'function'], 'array');
-        const card3 = new Card(3, 'What type of prototype method directly modifies the existing array?', ['mutator method', 'accessor method', 'iteration method'], 'mutator method');
-        const deck = new Deck([card1, card2, card3]);
-        deck.countCards();
-        expect(deck.countCards()).to.equal(3);
-    });
+  it('should initialize with an array of cards', () => {
+    expect(deck.cards).to.deep.equal([card1, card2, card3]);
+  });
+
+  it('should know how many cards are in the deck', () => {
+    deck.countCards();
+    expect(deck.countCards()).to.equal(3);
+  });
 });


### PR DESCRIPTION
Refactored Deck-Test file so that I am using a hook and `beforeEach()` function before running my `it` blocks.

In the Deck file, I noticed that the indentation from VS Code was different than the rest of my project that was done in Atom. I fixed the indentation and switched back to using Atom.